### PR TITLE
Fix CVE-2025-54798: Update tmp package to fix symlink vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3609,15 +3609,13 @@
       "dev": true
     },
     "node_modules/tmp": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "integrity": "sha512-c2mmfiBmND6SOVxzogm1oda0OJ1HZVIk/5n26N59dDTh80MUeavpiCls4PGAdkX1PFkKokLpcf7prSjCeXLsJg==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=0.4.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "js-yaml": "^4.1.1",
     "semver": "^7.6.3",
     "semver-regex": "3.1.4",
+    "tmp": "^0.2.4",
     "trim-newlines": "^3.0.1"
   }
 }


### PR DESCRIPTION
- Added npm override to force tmp@^0.2.4 or higher
- Updated from vulnerable tmp@0.0.28 to secure tmp@0.2.5
- Fixes arbitrary temporary file/directory write via symbolic link dir parameter
- Resolves GitHub issue #105

The tmp package (transitive dependency via grunt-contrib-compass) was vulnerable to symlink attacks. The override ensures all dependencies use the patched version 0.2.4+.